### PR TITLE
Support big ORC files in Windows

### DIFF
--- a/c++/src/OrcFile.cc
+++ b/c++/src/OrcFile.cc
@@ -30,6 +30,8 @@
 #include <io.h>
 #define S_IRUSR _S_IREAD
 #define S_IWUSR _S_IWRITE
+#define stat _stat64
+#define fstat _fstat64
 #else
 #include <unistd.h>
 #define O_BINARY 0


### PR DESCRIPTION
Use 64-bit versions of fstat to support files bigger than 2GB.

Jira Issue: https://issues.apache.org/jira/browse/ORC-702